### PR TITLE
Add messagebus to list of services to enable on RH

### DIFF
--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -7,5 +7,6 @@ system_ldap_packages:
     - oddjob-mkhomedir
 system_ldap_services:
     - sssd
+    - messagebus
     - oddjobd
 system_ldap_cacert: ca-bundle.crt


### PR DESCRIPTION
I was configuring a new CentOS 6.10 machine to accept Active Directory logins using your role. But Oddjobd fails to start. I did a bit of searching and found that Oddjobd requires access to the system message bus (dbus) and when trying to login to the machine with an AD account I got an error message. This pointed out that the message bus wasn’t working or was broken. So first thing I did was check the status of the messagebus and it wasn’t running. I started up messagebus service and then oddjobd started fine.

So messagebus service can be added as part of the list of ldap services to start.